### PR TITLE
Implement partial sort at most

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: "build/gcc-release"

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -49,14 +49,14 @@ jobs:
                     }
                   ]
                 },
-                { "cxxversions": ["c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++23", "c++20"],
                   "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
                 }
               ]
             },
             { "versions": ["14", "13"],
               "tests": [
-                { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++26", "c++23", "c++20"],
                   "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
                 }
               ]
@@ -64,7 +64,7 @@ jobs:
             {
               "versions": ["12", "11"],
               "tests": [
-                { "cxxversions": ["c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++23", "c++20"],
                   "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
                 }
               ]
@@ -83,7 +83,7 @@ jobs:
                     }
                   ]
                 },
-                { "cxxversions": ["c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++23", "c++20"],
                   "tests": [
                     {"stdlibs": ["libstdc++", "libc++"], "tests": ["Release.Default"]}
                   ]
@@ -92,7 +92,7 @@ jobs:
             },
             { "versions": ["21", "20", "19"],
               "tests": [
-                { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++26", "c++23", "c++20"],
                   "tests": [
                     {"stdlibs": ["libstdc++", "libc++"], "tests": ["Release.Default"]}
                   ]
@@ -101,10 +101,10 @@ jobs:
             },
             { "versions": ["18", "17"],
               "tests": [
-                { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++26", "c++23", "c++20"],
                   "tests": [{"stdlibs": ["libc++"], "tests": ["Release.Default"]}]
                 },
-                { "cxxversions": ["c++20", "c++17"],
+                { "cxxversions": ["c++20"],
                   "tests": [{"stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
                 }
               ]
@@ -113,7 +113,7 @@ jobs:
           "appleclang": [
             { "versions": ["latest"],
               "tests": [
-                { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++26", "c++23", "c++20"],
                   "tests": [{ "stdlibs": ["libc++"], "tests": ["Release.Default"]}]
                 }
               ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,11 +30,6 @@ include(infra/cmake/beman-install-library.cmake)
 add_library(beman.at_most INTERFACE)
 add_library(beman::at_most ALIAS beman.at_most)
 
-target_compile_features(beman.at_most INTERFACE cxx_std_20)
-set_target_properties(
-    beman.at_most
-    PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON
-)
 
 target_sources(
     beman.at_most

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,12 @@ include(infra/cmake/beman-install-library.cmake)
 add_library(beman.at_most INTERFACE)
 add_library(beman::at_most ALIAS beman.at_most)
 
+target_compile_features(beman.at_most INTERFACE cxx_std_20)
+set_target_properties(
+    beman.at_most
+    PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON
+)
+
 target_sources(
     beman.at_most
     PUBLIC FILE_SET HEADERS BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,6 @@ include(infra/cmake/beman-install-library.cmake)
 add_library(beman.at_most INTERFACE)
 add_library(beman::at_most ALIAS beman.at_most)
 
-
 target_sources(
     beman.at_most
     PUBLIC FILE_SET HEADERS BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"

--- a/include/beman/at_most/CMakeLists.txt
+++ b/include/beman/at_most/CMakeLists.txt
@@ -5,7 +5,5 @@ target_sources(
     PUBLIC
         FILE_SET HEADERS
             BASE_DIRS "${CMAKE_SOURCE_DIR}/include"
-            FILES 
-                at_most.hpp
-                partial_sort_at_most.hpp
+            FILES at_most.hpp partial_sort_at_most.hpp
 )

--- a/include/beman/at_most/CMakeLists.txt
+++ b/include/beman/at_most/CMakeLists.txt
@@ -5,5 +5,7 @@ target_sources(
     PUBLIC
         FILE_SET HEADERS
             BASE_DIRS "${CMAKE_SOURCE_DIR}/include"
-            FILES at_most.hpp
+            FILES 
+                at_most.hpp
+                partial_sort_at_most.hpp
 )

--- a/include/beman/at_most/at_most.hpp
+++ b/include/beman/at_most/at_most.hpp
@@ -3,6 +3,8 @@
 #ifndef BEMAN_AT_MOST_AT_MOST_HPP
 #define BEMAN_AT_MOST_AT_MOST_HPP
 
+#include <beman/at_most/partial_sort_at_most.hpp>
+
 namespace beman::at_most {
 /**
  * Returns the version of the beman.at_most library.

--- a/include/beman/at_most/at_most.hpp
+++ b/include/beman/at_most/at_most.hpp
@@ -3,7 +3,7 @@
 #ifndef BEMAN_AT_MOST_AT_MOST_HPP
 #define BEMAN_AT_MOST_AT_MOST_HPP
 
-#if __cplusplus < 202002L
+#if (defined(_MSVC_LANG) ? _MSVC_LANG : __cplusplus) < 202002L
     #error "beman.at_most requires at least C++20."
 #endif
 

--- a/include/beman/at_most/at_most.hpp
+++ b/include/beman/at_most/at_most.hpp
@@ -4,7 +4,7 @@
 #define BEMAN_AT_MOST_AT_MOST_HPP
 
 #if __cplusplus < 202002L
-#error "beman.at_most requires at least C++20."
+    #error "beman.at_most requires at least C++20."
 #endif
 
 #include <beman/at_most/partial_sort_at_most.hpp>

--- a/include/beman/at_most/at_most.hpp
+++ b/include/beman/at_most/at_most.hpp
@@ -3,6 +3,10 @@
 #ifndef BEMAN_AT_MOST_AT_MOST_HPP
 #define BEMAN_AT_MOST_AT_MOST_HPP
 
+#if __cplusplus < 202002L
+#error "beman.at_most requires at least C++20."
+#endif
+
 #include <beman/at_most/partial_sort_at_most.hpp>
 
 namespace beman::at_most {

--- a/include/beman/at_most/partial_sort_at_most.hpp
+++ b/include/beman/at_most/partial_sort_at_most.hpp
@@ -3,7 +3,7 @@
 #ifndef BEMAN_AT_MOST_PARTIAL_SORT_AT_MOST_HPP
 #define BEMAN_AT_MOST_PARTIAL_SORT_AT_MOST_HPP
 
-#if __cplusplus < 202002L
+#if (defined(_MSVC_LANG) ? _MSVC_LANG : __cplusplus) < 202002L
     #error "beman.at_most requires at least C++20."
 #endif
 

--- a/include/beman/at_most/partial_sort_at_most.hpp
+++ b/include/beman/at_most/partial_sort_at_most.hpp
@@ -3,6 +3,10 @@
 #ifndef BEMAN_AT_MOST_PARTIAL_SORT_AT_MOST_HPP
 #define BEMAN_AT_MOST_PARTIAL_SORT_AT_MOST_HPP
 
+#if __cplusplus < 202002L
+#error "beman.at_most requires at least C++20."
+#endif
+
 #include <algorithm>
 #include <iterator>
 #include <ranges>

--- a/include/beman/at_most/partial_sort_at_most.hpp
+++ b/include/beman/at_most/partial_sort_at_most.hpp
@@ -9,16 +9,6 @@
 
 namespace beman::at_most {
 
-/**
- * @brief Rearranges the elements in the range [first, last), such that the first min(n, last - first) elements
- * are sorted in ascending order and the remaining elements are left in an undefined order.
- *
- * Equivalent to:
- * @code
- * auto mid = first + std::min(n, std::distance(first, last));
- * std::partial_sort(first, mid, last, comp);
- * @endcode
- */
 template <typename RandomAccessIterator, typename Compare = std::less<>>
 constexpr void partial_sort_at_most(RandomAccessIterator                                                 first,
                                     RandomAccessIterator                                                 last,
@@ -35,4 +25,4 @@ constexpr void partial_sort_at_most(RandomAccessIterator                        
 
 } // namespace beman::at_most
 
-#endif // BEMAN_AT_MOST_PARTIAL_SORT_PASS_HPP
+#endif // BEMAN_AT_MOST_PARTIAL_SORT_AT_MOST_HPP

--- a/include/beman/at_most/partial_sort_at_most.hpp
+++ b/include/beman/at_most/partial_sort_at_most.hpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <ranges>
 
 namespace beman::at_most {
 
@@ -29,7 +30,7 @@ constexpr void partial_sort_at_most(RandomAccessIterator                        
     auto dist = std::distance(first, last);
     auto k    = std::min(n, dist);
     auto mid  = std::next(first, k);
-    std::ranges::partial_sort(std::ranges::subrange(first, last), mid, comp);
+    std::ranges::partial_sort(first, mid, last, comp);
 }
 
 } // namespace beman::at_most

--- a/include/beman/at_most/partial_sort_at_most.hpp
+++ b/include/beman/at_most/partial_sort_at_most.hpp
@@ -4,7 +4,7 @@
 #define BEMAN_AT_MOST_PARTIAL_SORT_AT_MOST_HPP
 
 #if __cplusplus < 202002L
-#error "beman.at_most requires at least C++20."
+    #error "beman.at_most requires at least C++20."
 #endif
 
 #include <algorithm>

--- a/include/beman/at_most/partial_sort_at_most.hpp
+++ b/include/beman/at_most/partial_sort_at_most.hpp
@@ -23,6 +23,36 @@ constexpr void partial_sort_at_most(RandomAccessIterator                        
     std::ranges::partial_sort(first, mid, last, comp);
 }
 
+namespace ranges {
+
+namespace __partial_sort_at_most {
+
+struct __fn {
+    template <std::random_access_iterator I,
+              std::sentinel_for<I>        S,
+              typename Comp = std::ranges::less,
+              typename Proj = std::identity>
+        requires std::sortable<I, Comp, Proj>
+    constexpr I operator()(I first, S last, std::iter_difference_t<I> n, Comp comp = {}, Proj proj = {}) const {
+        auto k   = std::max(std::iter_difference_t<I>(0), n);
+        auto mid = std::ranges::next(first, k, last);
+        return std::ranges::partial_sort(first, mid, last, comp, proj);
+    }
+
+    template <std::ranges::random_access_range R, typename Comp = std::ranges::less, typename Proj = std::identity>
+        requires std::sortable<std::ranges::iterator_t<R>, Comp, Proj>
+    constexpr std::ranges::borrowed_iterator_t<R>
+    operator()(R&& r, std::ranges::range_difference_t<R> n, Comp comp = {}, Proj proj = {}) const {
+        return operator()(std::ranges::begin(r), std::ranges::end(r), n, comp, proj);
+    }
+};
+
+} // namespace __partial_sort_at_most
+
+inline constexpr __partial_sort_at_most::__fn partial_sort_at_most{};
+
+} // namespace ranges
+
 } // namespace beman::at_most
 
 #endif // BEMAN_AT_MOST_PARTIAL_SORT_AT_MOST_HPP

--- a/include/beman/at_most/partial_sort_at_most.hpp
+++ b/include/beman/at_most/partial_sort_at_most.hpp
@@ -29,7 +29,7 @@ constexpr void partial_sort_at_most(RandomAccessIterator first,
     auto dist = std::distance(first, last);
     auto k = std::min(n, dist);
     auto mid = std::next(first, k);
-    std::partial_sort(first, mid, last, comp);
+    std::ranges::partial_sort(std::ranges::subrange(first, last), mid, comp);
 }
 
 } // namespace beman::at_most

--- a/include/beman/at_most/partial_sort_at_most.hpp
+++ b/include/beman/at_most/partial_sort_at_most.hpp
@@ -9,7 +9,7 @@
 namespace beman::at_most {
 
 /**
- * @brief Rearranges the elements in the range [first, last), such that the first min(n, last - first) elements 
+ * @brief Rearranges the elements in the range [first, last), such that the first min(n, last - first) elements
  * are sorted in ascending order and the remaining elements are left in an undefined order.
  *
  * Equivalent to:
@@ -19,16 +19,16 @@ namespace beman::at_most {
  * @endcode
  */
 template <typename RandomAccessIterator, typename Compare = std::less<>>
-constexpr void partial_sort_at_most(RandomAccessIterator first,
-                                    RandomAccessIterator last,
+constexpr void partial_sort_at_most(RandomAccessIterator                                                 first,
+                                    RandomAccessIterator                                                 last,
                                     typename std::iterator_traits<RandomAccessIterator>::difference_type n,
-                                    Compare comp = {}) {
+                                    Compare                                                              comp = {}) {
     if (n <= 0) {
         return;
     }
     auto dist = std::distance(first, last);
-    auto k = std::min(n, dist);
-    auto mid = std::next(first, k);
+    auto k    = std::min(n, dist);
+    auto mid  = std::next(first, k);
     std::ranges::partial_sort(std::ranges::subrange(first, last), mid, comp);
 }
 

--- a/include/beman/at_most/partial_sort_at_most.hpp
+++ b/include/beman/at_most/partial_sort_at_most.hpp
@@ -29,9 +29,9 @@ constexpr void partial_sort_at_most(RandomAccessIterator                        
 
 namespace ranges {
 
-namespace __partial_sort_at_most {
+namespace detail_partial_sort_at_most {
 
-struct __fn {
+struct fn {
     template <std::random_access_iterator I,
               std::sentinel_for<I>        S,
               typename Comp = std::ranges::less,
@@ -51,9 +51,9 @@ struct __fn {
     }
 };
 
-} // namespace __partial_sort_at_most
+} // namespace detail_partial_sort_at_most
 
-inline constexpr __partial_sort_at_most::__fn partial_sort_at_most{};
+inline constexpr detail_partial_sort_at_most::fn partial_sort_at_most{};
 
 } // namespace ranges
 

--- a/include/beman/at_most/partial_sort_at_most.hpp
+++ b/include/beman/at_most/partial_sort_at_most.hpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef BEMAN_AT_MOST_PARTIAL_SORT_AT_MOST_HPP
+#define BEMAN_AT_MOST_PARTIAL_SORT_AT_MOST_HPP
+
+#include <algorithm>
+#include <iterator>
+
+namespace beman::at_most {
+
+/**
+ * @brief Rearranges the elements in the range [first, last), such that the first min(n, last - first) elements 
+ * are sorted in ascending order and the remaining elements are left in an undefined order.
+ *
+ * Equivalent to:
+ * @code
+ * auto mid = first + std::min(n, std::distance(first, last));
+ * std::partial_sort(first, mid, last, comp);
+ * @endcode
+ */
+template <typename RandomAccessIterator, typename Compare = std::less<>>
+constexpr void partial_sort_at_most(RandomAccessIterator first,
+                                    RandomAccessIterator last,
+                                    typename std::iterator_traits<RandomAccessIterator>::difference_type n,
+                                    Compare comp = {}) {
+    if (n <= 0) {
+        return;
+    }
+    auto dist = std::distance(first, last);
+    auto k = std::min(n, dist);
+    auto mid = std::next(first, k);
+    std::partial_sort(first, mid, last, comp);
+}
+
+} // namespace beman::at_most
+
+#endif // BEMAN_AT_MOST_PARTIAL_SORT_PASS_HPP

--- a/tests/beman/at_most/CMakeLists.txt
+++ b/tests/beman/at_most/CMakeLists.txt
@@ -3,7 +3,11 @@
 find_package(GTest REQUIRED)
 
 add_executable(beman.at_most.tests)
-target_sources(beman.at_most.tests PRIVATE at_most.test.cpp)
+target_sources(beman.at_most.tests 
+    PRIVATE 
+        at_most.test.cpp
+        partial_sort_at_most.test.cpp
+)
 target_link_libraries(
     beman.at_most.tests
     PRIVATE beman::at_most GTest::gtest GTest::gtest_main

--- a/tests/beman/at_most/CMakeLists.txt
+++ b/tests/beman/at_most/CMakeLists.txt
@@ -3,10 +3,9 @@
 find_package(GTest REQUIRED)
 
 add_executable(beman.at_most.tests)
-target_sources(beman.at_most.tests 
-    PRIVATE 
-        at_most.test.cpp
-        partial_sort_at_most.test.cpp
+target_sources(
+    beman.at_most.tests
+    PRIVATE at_most.test.cpp partial_sort_at_most.test.cpp
 )
 target_link_libraries(
     beman.at_most.tests

--- a/tests/beman/at_most/at_most.test.cpp
+++ b/tests/beman/at_most/at_most.test.cpp
@@ -4,5 +4,3 @@
 #include <gtest/gtest.h>
 
 TEST(AtMostTest, VersionTest) { EXPECT_EQ(beman::at_most::version(), 1); }
-
-TEST(AtMostTest, BlankTest) { EXPECT_TRUE(true); }

--- a/tests/beman/at_most/partial_sort_at_most.test.cpp
+++ b/tests/beman/at_most/partial_sort_at_most.test.cpp
@@ -98,3 +98,71 @@ TEST(PartialSortAtMostTest, ConstexprStaticAssert) {
     static_assert(result, "partial_sort_at_most failed at compile-time");
     EXPECT_TRUE(result);
 }
+
+// Ranges
+
+struct Holder {
+    int  id;
+    int  val;
+    auto operator<=>(const Holder&) const = default;
+};
+
+template <typename Container, typename Compare = std::ranges::less, typename Proj = std::identity>
+void expect_ranges_equivalent_to_std(Container v, int n, Compare comp = {}, Proj proj = {}) {
+    auto v_std     = v;
+    auto v_at_most = v;
+
+    std::ranges::partial_sort(
+        v_std,
+        std::ranges::next(v_std.begin(), std::max(std::ptrdiff_t(0), std::ptrdiff_t(n)), v_std.end()),
+        comp,
+        proj);
+    ranges::partial_sort_at_most(v_at_most, n, comp, proj);
+
+    EXPECT_EQ(v_at_most, v_std);
+}
+
+TEST(PartialSortAtMostTest, RangesBasic) {
+    std::vector<int> v = {5, 4, 3, 2, 1};
+    expect_ranges_equivalent_to_std(v, 3);
+}
+
+TEST(PartialSortAtMostTest, RangesProjection) {
+    std::vector<Holder> v = {{1, 10}, {2, 5}, {3, 8}};
+    expect_ranges_equivalent_to_std(v, 2, std::ranges::less{}, &Holder::val);
+}
+
+struct ValueSentinel {
+    int  value;
+    bool operator==(auto it) const { return *it == value; }
+};
+
+TEST(PartialSortAtMostTest, RangesSentinel) {
+    std::vector<int> v         = {5, 4, 3, 2, 1, 99};
+    auto             v_std     = v;
+    auto             v_at_most = v;
+    auto             last      = ValueSentinel{99};
+
+    auto mid_std = std::ranges::next(v_std.begin(), 2, last);
+    std::ranges::partial_sort(v_std.begin(), mid_std, last);
+
+    ranges::partial_sort_at_most(v_at_most.begin(), last, 2);
+
+    auto it1 = v_at_most.begin();
+    auto it2 = v_std.begin();
+    while (!(last == it1)) {
+        EXPECT_EQ(*it1, *it2);
+        ++it1;
+        ++it2;
+    }
+}
+
+TEST(PartialSortAtMostTest, RangesConstexprStaticAssert) {
+    constexpr bool result = []() {
+        std::array<int, 5> a = {5, 4, 3, 2, 1};
+        ranges::partial_sort_at_most(a, 2);
+        return a[0] == 1 && a[1] == 2;
+    }();
+    static_assert(result);
+    EXPECT_TRUE(result);
+}

--- a/tests/beman/at_most/partial_sort_at_most.test.cpp
+++ b/tests/beman/at_most/partial_sort_at_most.test.cpp
@@ -9,85 +9,85 @@
 
 using namespace beman::at_most;
 
+/**
+ * @brief Helper for testing.
+ * Compares our beman::at_most::partial_sort_at_most output with 
+ * a manual call to std::partial_sort.
+ */
+template <typename Container, typename Compare = std::less<>>
+void expect_equivalent_to_std(Container v, int n, Compare comp = {}) {
+    auto v_std = v;
+    auto v_at_most = v;
+    auto size = std::distance(v_std.begin(), v_std.end());
+    auto k = std::min(static_cast<std::ptrdiff_t>(std::max(0, n)), size);
+    
+    std::partial_sort(v_std.begin(), v_std.begin() + k, v_std.end(), comp);
+    partial_sort_at_most(v_at_most.begin(), v_at_most.end(), n, comp);
+    
+    EXPECT_EQ(v_at_most, v_std);
+}
+
 // Boundary Clamping
 
-TEST(PartialSortAtMostTest, BoundaryZero) {
+TEST(PartialSortAtMostTest, ClampingZero) {
     std::vector<int> v = {5, 4, 3, 2, 1};
-    std::vector<int> original = v;
-    partial_sort_at_most(v.begin(), v.end(), 0);
-    EXPECT_EQ(v, original);
+    expect_equivalent_to_std(v, 0);
 }
 
-TEST(PartialSortAtMostTest, BoundaryNegative) {
+TEST(PartialSortAtMostTest, ClampingNegative) {
     std::vector<int> v = {5, 4, 3, 2, 1};
-    std::vector<int> original = v;
-    partial_sort_at_most(v.begin(), v.end(), -10);
-    EXPECT_EQ(v, original);
+    expect_equivalent_to_std(v, -10);
 }
 
-TEST(PartialSortAtMostTest, BoundarySize) {
-    std::vector<int> v = {5, 4, 3, 2, 1};
-    partial_sort_at_most(v.begin(), v.end(), 5);
-    EXPECT_TRUE(std::is_sorted(v.begin(), v.end()));
+TEST(PartialSortAtMostTest, ClampingOverSize) {
+    std::vector<int> v = {1, 5, 2, 4, 3};
+    expect_equivalent_to_std(v, 100);
 }
 
-TEST(PartialSortAtMostTest, BoundaryOverSize) {
-    std::vector<int> v = {5, 4, 3, 2, 1};
-    partial_sort_at_most(v.begin(), v.end(), 100);
-    EXPECT_TRUE(std::is_sorted(v.begin(), v.end()));
+TEST(PartialSortAtMostTest, ClampingAtSize) {
+    std::vector<int> v = {10, 20, 5, 1};
+    expect_equivalent_to_std(v, 4);
 }
 
 // Iterator Variety
 
-TEST(PartialSortAtMostTest, IteratorVector) {
-    std::vector<int> v = {10, 9, 8, 7, 6};
-    partial_sort_at_most(v.begin(), v.end(), 2);
-    EXPECT_EQ(v[0], 6);
-    EXPECT_EQ(v[1], 7);
-}
-
-TEST(PartialSortAtMostTest, IteratorRawPointer) {
-    int arr[] = {10, 9, 8, 7, 6};
+TEST(PartialSortAtMostTest, RawPointerArray) {
+    std::vector<int> v = {10, 5, 2, 8, 1};
+    int arr[] = {10, 5, 2, 8, 1};
+    
     partial_sort_at_most(arr, arr + 5, 2);
-    EXPECT_EQ(arr[0], 6);
-    EXPECT_EQ(arr[1], 7);
+    partial_sort_at_most(v.begin(), v.end(), 2);
+
+    for(int i=0; i<5; ++i) { EXPECT_EQ(arr[i], v[i]); }
 }
 
-TEST(PartialSortAtMostTest, IteratorDeque) {
-    std::deque<int> d = {10, 9, 8, 7, 6};
-    partial_sort_at_most(d.begin(), d.end(), 2);
-    EXPECT_EQ(d[0], 6);
-    EXPECT_EQ(d[1], 7);
+TEST(PartialSortAtMostTest, DequeVariety) {
+    std::deque<int> d = {10, 5, 2, 8, 1};
+    expect_equivalent_to_std(d, 3);
 }
 
 // Comparator Variety
 
-TEST(PartialSortAtMostTest, ComparatorGreater) {
+TEST(PartialSortAtMostTest, CustomGreater) {
     std::vector<int> v = {1, 2, 3, 4, 5};
-    partial_sort_at_most(v.begin(), v.end(), 2, std::greater<int>());
-    EXPECT_EQ(v[0], 5);
-    EXPECT_EQ(v[1], 4);
+    expect_equivalent_to_std(v, 3, std::greater<int>());
 }
 
-TEST(PartialSortAtMostTest, ComparatorLambda) {
-    std::vector<int> v = {5, 4, 3, 2, 1};
-    partial_sort_at_most(v.begin(), v.end(), 2, [](int a, int b) { return a < b; });
-    EXPECT_EQ(v[0], 1);
-    EXPECT_EQ(v[1], 2);
+TEST(PartialSortAtMostTest, CustomLambda) {
+    std::vector<int> v = {10, 5, 8, 1, 4};
+    expect_equivalent_to_std(v, 2, [](int a, int b) { return a < b; });
 }
 
 struct CustomLess {
     bool operator()(int a, int b) const { return a < b; }
 };
 
-TEST(PartialSortAtMostTest, ComparatorStruct) {
-    std::vector<int> v = {10, 20, 5, 1};
-    partial_sort_at_most(v.begin(), v.end(), 2, CustomLess{});
-    EXPECT_EQ(v[0], 1);
-    EXPECT_EQ(v[1], 5);
+TEST(PartialSortAtMostTest, CustomStruct) {
+    std::vector<int> v = {10, 5, 8, 1, 4};
+    expect_equivalent_to_std(v, 2, CustomLess{});
 }
 
-// Compile-Time (constexpr)
+// Compile-Time tests
 
 TEST(PartialSortAtMostTest, ConstexprStaticAssert) {
     constexpr bool result = []() {

--- a/tests/beman/at_most/partial_sort_at_most.test.cpp
+++ b/tests/beman/at_most/partial_sort_at_most.test.cpp
@@ -9,11 +9,6 @@
 
 using namespace beman::at_most;
 
-/**
- * @brief Helper for testing.
- * Compares our beman::at_most::partial_sort_at_most output with
- * a manual call to std::partial_sort.
- */
 template <typename Container, typename Compare = std::less<>>
 void expect_equivalent_to_std(Container v, int n, Compare comp = {}) {
     auto v_std     = v;

--- a/tests/beman/at_most/partial_sort_at_most.test.cpp
+++ b/tests/beman/at_most/partial_sort_at_most.test.cpp
@@ -11,19 +11,19 @@ using namespace beman::at_most;
 
 /**
  * @brief Helper for testing.
- * Compares our beman::at_most::partial_sort_at_most output with 
+ * Compares our beman::at_most::partial_sort_at_most output with
  * a manual call to std::partial_sort.
  */
 template <typename Container, typename Compare = std::less<>>
 void expect_equivalent_to_std(Container v, int n, Compare comp = {}) {
-    auto v_std = v;
+    auto v_std     = v;
     auto v_at_most = v;
-    auto size = std::distance(v_std.begin(), v_std.end());
-    auto k = std::min(static_cast<std::ptrdiff_t>(std::max(0, n)), size);
-    
+    auto size      = std::distance(v_std.begin(), v_std.end());
+    auto k         = std::min(static_cast<std::ptrdiff_t>(std::max(0, n)), size);
+
     std::partial_sort(v_std.begin(), v_std.begin() + k, v_std.end(), comp);
     partial_sort_at_most(v_at_most.begin(), v_at_most.end(), n, comp);
-    
+
     EXPECT_EQ(v_at_most, v_std);
 }
 
@@ -52,13 +52,15 @@ TEST(PartialSortAtMostTest, ClampingAtSize) {
 // Iterator Variety
 
 TEST(PartialSortAtMostTest, RawPointerArray) {
-    std::vector<int> v = {10, 5, 2, 8, 1};
-    int arr[] = {10, 5, 2, 8, 1};
-    
+    std::vector<int> v     = {10, 5, 2, 8, 1};
+    int              arr[] = {10, 5, 2, 8, 1};
+
     partial_sort_at_most(arr, arr + 5, 2);
     partial_sort_at_most(v.begin(), v.end(), 2);
 
-    for(int i=0; i<5; ++i) { EXPECT_EQ(arr[i], v[i]); }
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_EQ(arr[i], v[i]);
+    }
 }
 
 TEST(PartialSortAtMostTest, DequeVariety) {

--- a/tests/beman/at_most/partial_sort_at_most.test.cpp
+++ b/tests/beman/at_most/partial_sort_at_most.test.cpp
@@ -19,12 +19,17 @@ void expect_equivalent_to_std(Container v, int n, Compare comp = {}) {
     auto v_std     = v;
     auto v_at_most = v;
     auto size      = std::distance(v_std.begin(), v_std.end());
-    auto k         = std::min(static_cast<std::ptrdiff_t>(std::max(0, n)), size);
+    auto k         = std::max(static_cast<std::ptrdiff_t>(0), static_cast<std::ptrdiff_t>(n));
 
-    std::partial_sort(v_std.begin(), v_std.begin() + k, v_std.end(), comp);
-    partial_sort_at_most(v_at_most.begin(), v_at_most.end(), n, comp);
-
-    EXPECT_EQ(v_at_most, v_std);
+    if (k == 0) {
+        partial_sort_at_most(v_at_most.begin(), v_at_most.end(), n, comp);
+        EXPECT_EQ(v_at_most, v_std);
+    } else {
+        k = std::min(k, size);
+        std::partial_sort(v_std.begin(), v_std.begin() + k, v_std.end(), comp);
+        partial_sort_at_most(v_at_most.begin(), v_at_most.end(), n, comp);
+        EXPECT_EQ(v_at_most, v_std);
+    }
 }
 
 // Boundary Clamping

--- a/tests/beman/at_most/partial_sort_at_most.test.cpp
+++ b/tests/beman/at_most/partial_sort_at_most.test.cpp
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <beman/at_most/partial_sort_at_most.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+#include <deque>
+#include <algorithm>
+#include <array>
+
+using namespace beman::at_most;
+
+// Boundary Clamping
+
+TEST(PartialSortAtMostTest, BoundaryZero) {
+    std::vector<int> v = {5, 4, 3, 2, 1};
+    std::vector<int> original = v;
+    partial_sort_at_most(v.begin(), v.end(), 0);
+    EXPECT_EQ(v, original);
+}
+
+TEST(PartialSortAtMostTest, BoundaryNegative) {
+    std::vector<int> v = {5, 4, 3, 2, 1};
+    std::vector<int> original = v;
+    partial_sort_at_most(v.begin(), v.end(), -10);
+    EXPECT_EQ(v, original);
+}
+
+TEST(PartialSortAtMostTest, BoundarySize) {
+    std::vector<int> v = {5, 4, 3, 2, 1};
+    partial_sort_at_most(v.begin(), v.end(), 5);
+    EXPECT_TRUE(std::is_sorted(v.begin(), v.end()));
+}
+
+TEST(PartialSortAtMostTest, BoundaryOverSize) {
+    std::vector<int> v = {5, 4, 3, 2, 1};
+    partial_sort_at_most(v.begin(), v.end(), 100);
+    EXPECT_TRUE(std::is_sorted(v.begin(), v.end()));
+}
+
+// Iterator Variety
+
+TEST(PartialSortAtMostTest, IteratorVector) {
+    std::vector<int> v = {10, 9, 8, 7, 6};
+    partial_sort_at_most(v.begin(), v.end(), 2);
+    EXPECT_EQ(v[0], 6);
+    EXPECT_EQ(v[1], 7);
+}
+
+TEST(PartialSortAtMostTest, IteratorRawPointer) {
+    int arr[] = {10, 9, 8, 7, 6};
+    partial_sort_at_most(arr, arr + 5, 2);
+    EXPECT_EQ(arr[0], 6);
+    EXPECT_EQ(arr[1], 7);
+}
+
+TEST(PartialSortAtMostTest, IteratorDeque) {
+    std::deque<int> d = {10, 9, 8, 7, 6};
+    partial_sort_at_most(d.begin(), d.end(), 2);
+    EXPECT_EQ(d[0], 6);
+    EXPECT_EQ(d[1], 7);
+}
+
+// Comparator Variety
+
+TEST(PartialSortAtMostTest, ComparatorGreater) {
+    std::vector<int> v = {1, 2, 3, 4, 5};
+    partial_sort_at_most(v.begin(), v.end(), 2, std::greater<int>());
+    EXPECT_EQ(v[0], 5);
+    EXPECT_EQ(v[1], 4);
+}
+
+TEST(PartialSortAtMostTest, ComparatorLambda) {
+    std::vector<int> v = {5, 4, 3, 2, 1};
+    partial_sort_at_most(v.begin(), v.end(), 2, [](int a, int b) { return a < b; });
+    EXPECT_EQ(v[0], 1);
+    EXPECT_EQ(v[1], 2);
+}
+
+struct CustomLess {
+    bool operator()(int a, int b) const { return a < b; }
+};
+
+TEST(PartialSortAtMostTest, ComparatorStruct) {
+    std::vector<int> v = {10, 20, 5, 1};
+    partial_sort_at_most(v.begin(), v.end(), 2, CustomLess{});
+    EXPECT_EQ(v[0], 1);
+    EXPECT_EQ(v[1], 5);
+}
+
+// Compile-Time (constexpr)
+
+TEST(PartialSortAtMostTest, ConstexprStaticAssert) {
+    constexpr bool result = []() {
+        std::array<int, 5> a = {5, 4, 3, 2, 1};
+        partial_sort_at_most(a.begin(), a.end(), 2);
+        return a[0] == 1 && a[1] == 2;
+    }();
+    static_assert(result, "partial_sort_at_most failed at compile-time");
+    EXPECT_TRUE(result);
+}

--- a/tests/beman/at_most/partial_sort_at_most.test.cpp
+++ b/tests/beman/at_most/partial_sort_at_most.test.cpp
@@ -21,15 +21,13 @@ void expect_equivalent_to_std(Container v, int n, Compare comp = {}) {
     auto size      = std::distance(v_std.begin(), v_std.end());
     auto k         = std::max(static_cast<std::ptrdiff_t>(0), static_cast<std::ptrdiff_t>(n));
 
-    if (k == 0) {
-        partial_sort_at_most(v_at_most.begin(), v_at_most.end(), n, comp);
-        EXPECT_EQ(v_at_most, v_std);
-    } else {
+    if (k != 0) {
         k = std::min(k, size);
         std::partial_sort(v_std.begin(), v_std.begin() + k, v_std.end(), comp);
-        partial_sort_at_most(v_at_most.begin(), v_at_most.end(), n, comp);
-        EXPECT_EQ(v_at_most, v_std);
     }
+
+    partial_sort_at_most(v_at_most.begin(), v_at_most.end(), n, comp);
+    EXPECT_EQ(v_at_most, v_std);
 }
 
 // Boundary Clamping


### PR DESCRIPTION
Implemented part of [P3735](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3735r1.html), specifically #1 

* Added `partial_sort_at_most` in `partial_sort_at_most.hpp`, with overloads for both [`iterator`](https://github.com/bemanproject/at_most/pull/3/changes#diff-4c3d42c3b32689ff465a9a28a8854a7cc4126d9d82ef87e01bccb3c8c4933d59R12-R24) and [`range`](https://github.com/bemanproject/at_most/pull/3/changes#diff-4c3d42c3b32689ff465a9a28a8854a7cc4126d9d82ef87e01bccb3c8c4933d59R26-R54) support 

Notable:
* the `beman::at_most::ranges` one is using Niebloid objects (like other things in `std::ranges` - this thing was fun to learn about)
* everything is `constexpr`
* testing tests against the output of `std::partial_sort` and/or `std::ranges::partial_sort`, to check especially the logic not the sorting itself
* the classic C++ version of `partial_sort_at_most`, `beman::at_most::partial_sort_at_most` is using `std::ranges::partial_sort` internally, instead of `std::partial_sort`, because the latter does not support `constexpr` on all compilers - found this out on [this CI run](https://github.com/bemanproject/at_most/pull/3/changes/a46d60bdfebb01c8ace53284d2c75b6c5555b934)
* haha might have understimated this paper, or overestimated my cpp knowledge going into this. Had to do a lot of research into how modern C++ works in order to implement this well and I ended up learning a lot of cool things. Very glad I took this issue :D

