### PR TITLE
Implement nth element at most

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 This can be used as a template for those intending to write Beman libraries.
 It may also find use as a minimal and modern  C++ project structure.
 
-**Implements**: `std::identity` proposed in [Standard Library Concepts (P3735R1)](https://wg21.link/P3735R1).
+**Implements**: `partial_sort_at_most` and `nth_element_at_most` proposed in [partial_sort_at_most, nth_element_at_most (P3735R1)](https://wg21.link/P3735R1).
 
 **Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md#under-development-and-not-yet-ready-for-production-use)
 
@@ -21,65 +21,29 @@ It may also find use as a minimal and modern  C++ project structure.
 
 ## Usage
 
-`std::identity` is a function object type whose `operator()` returns its argument unchanged.
-`std::identity` serves as the default projection in constrained algorithms.
-Its direct usage is usually not needed.
+`partial_sort_at_most` and `nth_element_at_most` provide safer, count-based alternatives to `partial_sort` and `nth_element`.
 
-### Usage: default projection in constrained algorithms
+### Usage: partial_sort_at_most
 
-The following code snippet illustrates how we can achieve a default projection using `beman::at_most::identity`:
+The following code snippet illustrates how we can sort the "at most" 3 smallest elements of a vector:
 
 ```cpp
 #include <beman/at_most/at_most.hpp>
+#include <vector>
+#include <iostream>
 
-namespace exe = beman::at_most;
+int main() {
+    std::vector<int> v = {5, 4, 3, 2, 1};
 
-// Class with a pair of values.
-struct Pair
-{
-    int n;
-    std::string s;
+    // Sort at most 3 elements
+    beman::at_most::partial_sort_at_most(v.begin(), v.end(), 3);
 
-    // Output the pair in the form {n, s}.
-    // Used by the range-printer if no custom projection is provided (default: identity projection).
-    friend std::ostream &operator<<(std::ostream &os, const Pair &p)
-    {
-        return os << "Pair" << '{' << p.n << ", " << p.s << '}';
-    }
-};
-
-// A range-printer that can print projected (modified) elements of a range.
-// All the elements of the range are printed in the form {element1, element2, ...}.
-// e.g., pairs with identity: Pair{1, one}, Pair{2, two}, Pair{3, three}
-// e.g., pairs with custom projection: {1:one, 2:two, 3:three}
-template <std::ranges::input_range R,
-          typename Projection>
-void print(const std::string_view rem, R &&range, Projection projection = exe::identity>)
-{
-    std::cout << rem << '{';
-    std::ranges::for_each(
-        range,
-        [O = 0](const auto &o) mutable
-        { std::cout << (O++ ? ", " : "") << o; },
-        projection);
-    std::cout << "}\n";
-};
-
-int main()
-{
-    // A vector of pairs to print.
-    const std::vector<Pair> pairs = {
-        {1, "one"},
-        {2, "two"},
-        {3, "three"},
-    };
-
-    // Print the pairs using the default projection.
-    print("\tpairs with beman: ", pairs);
+    // Output: 1 2 3 5 4 (first 3 are sorted)
+    for (int x : v) std::cout << x << " ";
+    std::cout << "\n";
 
     return 0;
 }
-
 ```
 
 Full runnable examples can be found in [`examples/`](examples/).

--- a/include/beman/at_most/CMakeLists.txt
+++ b/include/beman/at_most/CMakeLists.txt
@@ -5,5 +5,5 @@ target_sources(
     PUBLIC
         FILE_SET HEADERS
             BASE_DIRS "${CMAKE_SOURCE_DIR}/include"
-            FILES at_most.hpp partial_sort_at_most.hpp
+            FILES at_most.hpp partial_sort_at_most.hpp nth_element_at_most.hpp
 )

--- a/include/beman/at_most/at_most.hpp
+++ b/include/beman/at_most/at_most.hpp
@@ -8,6 +8,7 @@
 #endif
 
 #include <beman/at_most/partial_sort_at_most.hpp>
+#include <beman/at_most/nth_element_at_most.hpp>
 
 namespace beman::at_most {
 /**

--- a/include/beman/at_most/nth_element_at_most.hpp
+++ b/include/beman/at_most/nth_element_at_most.hpp
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef BEMAN_AT_MOST_NTH_ELEMENT_AT_MOST_HPP
+#define BEMAN_AT_MOST_NTH_ELEMENT_AT_MOST_HPP
+
+#if (defined(_MSVC_LANG) ? _MSVC_LANG : __cplusplus) < 202002L
+    #error "beman.at_most requires at least C++20."
+#endif
+
+#include <algorithm>
+#include <iterator>
+#include <ranges>
+
+namespace beman::at_most {
+
+template <typename RandomAccessIterator, typename Compare = std::less<>>
+constexpr void nth_element_at_most(RandomAccessIterator                                                 first,
+                                   RandomAccessIterator                                                 last,
+                                   typename std::iterator_traits<RandomAccessIterator>::difference_type n,
+                                   Compare                                                              comp = {}) {
+    if (n < 0) {
+        return;
+    }
+    auto dist = std::distance(first, last);
+    if (n >= dist) {
+        return;
+    }
+    auto nth = std::next(first, n);
+    std::ranges::nth_element(first, nth, last, comp);
+}
+
+namespace ranges {
+
+namespace detail_nth_element_at_most {
+
+struct fn {
+    template <std::random_access_iterator I,
+              std::sentinel_for<I>        S,
+              typename Comp = std::ranges::less,
+              typename Proj = std::identity>
+        requires std::sortable<I, Comp, Proj>
+    constexpr I operator()(I first, S last, std::iter_difference_t<I> n, Comp comp = {}, Proj proj = {}) const {
+        if (n < 0) {
+            return std::ranges::next(first, last);
+        }
+        auto k   = n;
+        auto nth = std::ranges::next(first, k, last);
+        if (nth == last) {
+            return nth;
+        }
+        return std::ranges::nth_element(first, nth, last, comp, proj);
+    }
+
+    template <std::ranges::random_access_range R, typename Comp = std::ranges::less, typename Proj = std::identity>
+        requires std::sortable<std::ranges::iterator_t<R>, Comp, Proj>
+    constexpr std::ranges::borrowed_iterator_t<R>
+    operator()(R&& r, std::ranges::range_difference_t<R> n, Comp comp = {}, Proj proj = {}) const {
+        return operator()(std::ranges::begin(r), std::ranges::end(r), n, comp, proj);
+    }
+};
+
+} // namespace detail_nth_element_at_most
+
+inline constexpr detail_nth_element_at_most::fn nth_element_at_most{};
+
+} // namespace ranges
+
+} // namespace beman::at_most
+
+#endif // BEMAN_AT_MOST_NTH_ELEMENT_AT_MOST_HPP

--- a/tests/beman/at_most/CMakeLists.txt
+++ b/tests/beman/at_most/CMakeLists.txt
@@ -9,7 +9,7 @@ target_sources(
 )
 target_link_libraries(
     beman.at_most.tests
-    PRIVATE beman::at_most GTest::gtest GTest::gtest_main
+    PRIVATE beman::at_most GTest::gtest_main
 )
 
 include(GoogleTest)

--- a/tests/beman/at_most/CMakeLists.txt
+++ b/tests/beman/at_most/CMakeLists.txt
@@ -5,7 +5,10 @@ find_package(GTest REQUIRED)
 add_executable(beman.at_most.tests)
 target_sources(
     beman.at_most.tests
-    PRIVATE at_most.test.cpp partial_sort_at_most.test.cpp
+    PRIVATE
+        at_most.test.cpp
+        partial_sort_at_most.test.cpp
+        nth_element_at_most.test.cpp
 )
 target_link_libraries(
     beman.at_most.tests

--- a/tests/beman/at_most/nth_element_at_most.test.cpp
+++ b/tests/beman/at_most/nth_element_at_most.test.cpp
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <beman/at_most/nth_element_at_most.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+#include <algorithm>
+#include <array>
+
+using namespace beman::at_most;
+
+template <typename Container, typename Compare = std::less<>>
+void expect_equivalent_to_std(Container v, int n, Compare comp = {}) {
+    auto v_std     = v;
+    auto v_at_most = v;
+    auto size      = static_cast<std::ptrdiff_t>(std::distance(v_std.begin(), v_std.end()));
+
+    if (n >= 0 && n < size) {
+        std::nth_element(v_std.begin(), v_std.begin() + n, v_std.end(), comp);
+    }
+
+    nth_element_at_most(v_at_most.begin(), v_at_most.end(), n, comp);
+
+    if (n >= 0 && n < size) {
+        EXPECT_EQ(v_at_most[n], v_std[n]);
+        for (std::ptrdiff_t i = 0; i < n; ++i) {
+            EXPECT_FALSE(comp(v_at_most[n], v_at_most[i]));
+        }
+        for (std::ptrdiff_t i = n + 1; i < size; ++i) {
+            EXPECT_FALSE(comp(v_at_most[i], v_at_most[n]));
+        }
+    } else {
+        EXPECT_EQ(v_at_most, v_std);
+    }
+}
+
+TEST(NthElementAtMostTest, Basic) {
+    std::vector<int> v = {5, 4, 3, 2, 1};
+    expect_equivalent_to_std(v, 2);
+}
+
+TEST(NthElementAtMostTest, EdgeCases) {
+    std::vector<int> v = {1, 2, 3};
+    expect_equivalent_to_std(v, 0);
+    expect_equivalent_to_std(v, 2);
+    expect_equivalent_to_std(v, -1);
+    expect_equivalent_to_std(v, 3);
+    expect_equivalent_to_std(v, 100);
+}
+
+TEST(NthElementAtMostTest, ConstexprStaticAssert) {
+    constexpr bool result = []() {
+        std::array<int, 5> a = {5, 4, 3, 2, 1};
+        nth_element_at_most(a.begin(), a.end(), 2);
+        return a[2] == 3;
+    }();
+    static_assert(result);
+    EXPECT_TRUE(result);
+}
+
+// Ranges
+
+struct Holder {
+    int  id;
+    int  val;
+    auto operator<=>(const Holder&) const = default;
+};
+
+template <typename Container, typename Compare = std::ranges::less, typename Proj = std::identity>
+void expect_ranges_equivalent_to_std(Container v, int n, Compare comp = {}, Proj proj = {}) {
+    auto v_std     = v;
+    auto v_at_most = v;
+    auto size      = static_cast<std::ptrdiff_t>(std::ranges::distance(v_std));
+
+    if (n >= 0 && n < size) {
+        std::ranges::nth_element(v_std, v_std.begin() + n, comp, proj);
+    }
+
+    ranges::nth_element_at_most(v_at_most, n, comp, proj);
+
+    if (n >= 0 && n < size) {
+        EXPECT_EQ(std::invoke(proj, v_at_most[n]), std::invoke(proj, v_std[n]));
+    } else {
+        EXPECT_EQ(v_at_most, v_std);
+    }
+}
+
+TEST(NthElementAtMostTest, RangesBasic) {
+    std::vector<int> v = {5, 4, 3, 2, 1};
+    expect_ranges_equivalent_to_std(v, 2);
+}
+
+TEST(NthElementAtMostTest, RangesProjection) {
+    std::vector<Holder> v = {{1, 10}, {2, 5}, {3, 8}};
+    expect_ranges_equivalent_to_std(v, 1, std::ranges::less{}, &Holder::val);
+}
+
+TEST(NthElementAtMostTest, RangesConstexprStaticAssert) {
+    constexpr bool result = []() {
+        std::array<int, 5> a = {5, 4, 3, 2, 1};
+        ranges::nth_element_at_most(a, 0);
+        return a[0] == 1;
+    }();
+    static_assert(result);
+    EXPECT_TRUE(result);
+}


### PR DESCRIPTION
Implemented part of [P3735](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3735r1.html), specifically #2

* Added `nth_element_at_most` in `nth_element_at_most.hpp`, with overloads for both [`iterator`](https://github.com/bemanproject/at_most/pull/4/changes#diff-d4239d529b66bb287232354a56c02df1d802315493cca71f4903d30a1ef22d63R16-R30) and [`range`](https://github.com/bemanproject/at_most/pull/4/changes#diff-d4239d529b66bb287232354a56c02df1d802315493cca71f4903d30a1ef22d63R32-R66) support 
* Very similar to #3
* Also this updates [README.md](https://github.com/bemanproject/at_most/pull/4/changes#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)

